### PR TITLE
fix: resolve argument parsing conflict in logs subcommand

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -14,6 +14,65 @@ describe('CLI Integration Tests', () => {
     });
   });
 
+  describe('backward compatibility', () => {
+    it('should inject logs subcommand when URL is passed directly', async () => {
+      // Save original process.argv
+      const originalArgv = [...process.argv];
+      
+      // Test with direct URL
+      process.argv = ['node', 'cli.js', 'https://circleci.com/gh/org/repo/123'];
+      
+      // Re-import to trigger the preprocessing
+      vi.resetModules();
+      await import('./index.js');
+      
+      // Check that logs was injected
+      expect(process.argv[2]).toBe('logs');
+      expect(process.argv[3]).toBe('https://circleci.com/gh/org/repo/123');
+      
+      // Restore original argv
+      process.argv = originalArgv;
+    });
+
+    it('should not modify argv when subcommand is already present', async () => {
+      // Save original process.argv
+      const originalArgv = [...process.argv];
+      
+      // Test with explicit logs subcommand
+      process.argv = ['node', 'cli.js', 'logs', 'https://circleci.com/gh/org/repo/123'];
+      
+      // Re-import to trigger the preprocessing
+      vi.resetModules();
+      await import('./index.js');
+      
+      // Check that argv was not modified
+      expect(process.argv[2]).toBe('logs');
+      expect(process.argv[3]).toBe('https://circleci.com/gh/org/repo/123');
+      
+      // Restore original argv
+      process.argv = originalArgv;
+    });
+
+    it('should not modify argv for tests subcommand', async () => {
+      // Save original process.argv
+      const originalArgv = [...process.argv];
+      
+      // Test with tests subcommand
+      process.argv = ['node', 'cli.js', 'tests', 'https://circleci.com/gh/org/repo/123'];
+      
+      // Re-import to trigger the preprocessing
+      vi.resetModules();
+      await import('./index.js');
+      
+      // Check that argv was not modified
+      expect(process.argv[2]).toBe('tests');
+      expect(process.argv[3]).toBe('https://circleci.com/gh/org/repo/123');
+      
+      // Restore original argv
+      process.argv = originalArgv;
+    });
+  });
+
   describe('subcommands', () => {
     it('should have logs subcommand', async () => {
       const { program } = await import('./index.js');

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -18,18 +18,18 @@ describe('CLI Integration Tests', () => {
     it('should inject logs subcommand when URL is passed directly', async () => {
       // Save original process.argv
       const originalArgv = [...process.argv];
-      
+
       // Test with direct URL
       process.argv = ['node', 'cli.js', 'https://circleci.com/gh/org/repo/123'];
-      
+
       // Re-import to trigger the preprocessing
       vi.resetModules();
       await import('./index.js');
-      
+
       // Check that logs was injected
       expect(process.argv[2]).toBe('logs');
       expect(process.argv[3]).toBe('https://circleci.com/gh/org/repo/123');
-      
+
       // Restore original argv
       process.argv = originalArgv;
     });
@@ -37,18 +37,18 @@ describe('CLI Integration Tests', () => {
     it('should not modify argv when subcommand is already present', async () => {
       // Save original process.argv
       const originalArgv = [...process.argv];
-      
+
       // Test with explicit logs subcommand
       process.argv = ['node', 'cli.js', 'logs', 'https://circleci.com/gh/org/repo/123'];
-      
+
       // Re-import to trigger the preprocessing
       vi.resetModules();
       await import('./index.js');
-      
+
       // Check that argv was not modified
       expect(process.argv[2]).toBe('logs');
       expect(process.argv[3]).toBe('https://circleci.com/gh/org/repo/123');
-      
+
       // Restore original argv
       process.argv = originalArgv;
     });
@@ -56,18 +56,18 @@ describe('CLI Integration Tests', () => {
     it('should not modify argv for tests subcommand', async () => {
       // Save original process.argv
       const originalArgv = [...process.argv];
-      
+
       // Test with tests subcommand
       process.argv = ['node', 'cli.js', 'tests', 'https://circleci.com/gh/org/repo/123'];
-      
+
       // Re-import to trigger the preprocessing
       vi.resetModules();
       await import('./index.js');
-      
+
       // Check that argv was not modified
       expect(process.argv[2]).toBe('tests');
       expect(process.argv[3]).toBe('https://circleci.com/gh/org/repo/123');
-      
+
       // Restore original argv
       process.argv = originalArgv;
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,21 +16,12 @@ program.addCommand(createLogsCommand());
 program.addCommand(createTestsCommand());
 
 // For backward compatibility: support direct URL as first argument
-program
-  .argument('[command]', 'Command or URL')
-  .argument('[url]', 'URL for subcommand')
-  .action((commandOrUrl, _url) => {
-    // If first argument looks like a URL, treat it as logs command
-    if (commandOrUrl && (commandOrUrl.startsWith('http') || commandOrUrl.includes('circleci'))) {
-      // Get all original arguments after the program name
-      const originalArgs = process.argv.slice(2);
-      // Insert 'logs' before the URL
-      const newArgs = ['logs', ...originalArgs];
-      // Re-parse with logs subcommand
-      program.parse(newArgs, { from: 'user' });
-    } else if (!commandOrUrl) {
-      // No arguments provided, show help
-      program.outputHelp();
-    }
-    // Otherwise, let commander handle it normally (it's a subcommand)
-  });
+// Check if first argument is a URL before commander processes it
+const firstArg = process.argv[2];
+if (firstArg && (firstArg.startsWith('http') || firstArg.includes('circleci'))) {
+  // Insert 'logs' before the URL for backward compatibility
+  const originalArgs = process.argv.slice(2);
+  const newArgs = ['logs', ...originalArgs];
+  // Override process.argv for commander to parse
+  process.argv = [...process.argv.slice(0, 2), ...newArgs];
+}


### PR DESCRIPTION
## Summary
- Fixed "too many arguments" error when using `circleci-logs logs <url>`
- Resolved conflict between main program arguments and subcommand arguments
- Maintained backward compatibility for direct URL usage

## Problem
When running `circleci-logs logs <url>`, Commander was interpreting:
- `logs` as the `[command]` argument on the main program
- `<url>` as the `[url]` argument on the main program

This conflicted with the logs subcommand's own argument definition which expects only one `<url>` argument.

## Solution
- Removed argument definitions from the main program that were conflicting with subcommand arguments
- Implemented backward compatibility via process.argv preprocessing instead of Commander's action handler
- When a URL is passed as the first argument, we now inject 'logs' before Commander parses the arguments

## Testing
All three usage patterns now work correctly:
- `circleci-logs logs <url>` - Explicit subcommand usage
- `circleci-logs <url>` - Backward compatibility (automatically uses logs)
- `circleci-logs tests <url>` - Tests subcommand

All existing tests pass without modification.

🤖 Generated with [Claude Code](https://claude.ai/code)