### PR TITLE
feat: use gh release create --generate-notes for automatic release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,41 +62,10 @@ jobs:
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
       
-      - name: Generate release notes
-        id: release-notes
-        run: |
-          # Get the previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating release notes from $PREV_TAG to $GITHUB_REF_NAME"
-            RELEASE_NOTES=$(gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-              -f "tag_name=$GITHUB_REF_NAME" \
-              -f "previous_tag_name=$PREV_TAG" \
-              --jq '.body')
-          else
-            echo "First release, generating notes from beginning"
-            RELEASE_NOTES=$(gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-              -f "tag_name=$GITHUB_REF_NAME" \
-              --jq '.body')
-          fi
-          
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$RELEASE_NOTES" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ github.token }}
-      
       - name: Create GitHub Release
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --notes "$RELEASE_NOTES"
+            --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Simplified the release workflow to use `gh release create --generate-notes`
- Removed manual release notes generation via GitHub API

## Changes
- Replaced 33 lines of manual release notes generation with a single `--generate-notes` flag
- The gh CLI's built-in flag automatically generates release notes based on merged PRs and commits
- This is more maintainable and leverages GitHub's native release notes generation

## Benefits
- Simpler and more maintainable workflow
- Automatic inclusion of PR titles and contributors
- Consistent release notes format across all releases
- Less code to maintain

🤖 Generated with [Claude Code](https://claude.ai/code)