### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/scripts/check-codeql-sarif.mjs
+++ b/.github/scripts/check-codeql-sarif.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const sarifPath = process.argv[2];
+if (!sarifPath) {
+  console.error("Usage: node .github/scripts/check-codeql-sarif.mjs <result.sarif>");
+  process.exit(2);
+}
+
+const sarif = JSON.parse(readFileSync(sarifPath, "utf8"));
+const findings = [];
+
+for (const run of sarif.runs ?? []) {
+  const rules = new Map((run.tool?.driver?.rules ?? []).map((rule) => [rule.id, rule]));
+  for (const result of run.results ?? []) {
+    const rule = rules.get(result.ruleId);
+    const level = result.level ?? rule?.defaultConfiguration?.level ?? "warning";
+    const message = result.message?.text ?? result.message?.markdown ?? "";
+    const location = result.locations?.[0]?.physicalLocation;
+    const uri = location?.artifactLocation?.uri ?? "unknown";
+    const line = location?.region?.startLine ?? 1;
+    findings.push({ ruleId: result.ruleId ?? "unknown", level, uri, line, message });
+  }
+}
+
+if (findings.length > 0) {
+  console.error(`CodeQL produced ${findings.length} finding(s).`);
+  for (const finding of findings) {
+    console.error(`- ${finding.level} ${finding.ruleId} ${finding.uri}:${finding.line} ${finding.message}`);
+  }
+  process.exit(1);
+}
+
+console.log("No CodeQL findings.");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,62 +6,75 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: pnpm/action-setup@v4
-      
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Run format check
         run: pnpm run format:check
-      
+
       - name: Run lint
         run: pnpm run lint
-      
+
       - name: Run type check
         run: pnpm run typecheck
 
   test:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
     strategy:
       matrix:
         node-version: [22.x, 24.x]
-    
+
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: pnpm/action-setup@v4
-      
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      
+          cache: "pnpm"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Run tests
         run: pnpm test
-      
+
       - name: Build
         run: pnpm run build
-      
+
       - name: Test CLI help
         run: node dist/cli.js --help
-      
+
       - name: Test CLI version
         run: node dist/cli.js --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,69 +3,80 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
-      id-token: write  # OIDC for npm trusted publishing
+      id-token: write # OIDC for npm trusted publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      
+
       - name: Get version from tag
         id: version
         run: |
+          set -euo pipefail
+
           # Get version from tag (remove 'v' prefix)
           VERSION=${GITHUB_REF_NAME#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
           # Get package name from package.json
           PACKAGE_NAME=$(jq -r '.name' package.json)
-          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
-          
+          echo "name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+
           # Verify package.json version matches tag
           PACKAGE_VERSION=$(jq -r '.version' package.json)
           if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
             echo "Error: package.json version ($PACKAGE_VERSION) doesn't match tag version ($VERSION)"
             exit 1
           fi
-      
+        shell: bash
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
-      
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
       - name: Install latest npm
         run: |
+          set -euo pipefail
+
           echo "Current npm version: $(npm -v)"
           npm install -g npm@latest
           echo "Updated npm version: $(npm -v)"
-      
+        shell: bash
+
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-      
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Build
         run: pnpm run build
-      
+
       - name: Run tests
         run: pnpm test
-      
+
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
-      
+
       - name: Create GitHub Release
         run: |
+          set -euo pipefail
+
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,185 @@
+name: workflow-lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/ghalint.y*ml"
+      - ".github/zizmor.y*ml"
+      - ".pinact.y*ml"
+      - "renovate.json5"
+      - "zizmor.y*ml"
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download pinact
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/pinact
+          PINACT_VERSION: v4.1.0
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          archive="pinact_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o "/tmp/${archive}" "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/${archive}"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/pinact_checksums.txt "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/pinact_${PINACT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  ${archive}$" pinact_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp
+          sudo install -m 0755 /tmp/pinact /usr/local/bin/pinact
+          pinact version
+        shell: bash
+
+      - name: Check pinned action refs
+        run: pinact run --check
+        shell: bash
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        id: get_actionlint
+        env:
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          ACTIONLINT_VERSION: v1.7.12
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/download-actionlint.bash "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
+          bash /tmp/download-actionlint.bash "${ACTIONLINT_VERSION#v}"
+        shell: bash
+
+      - name: Check workflow files
+        env:
+          ACTIONLINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+        run: |
+          "${ACTIONLINT_EXECUTABLE}" -color
+        shell: bash
+
+  ghalint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download ghalint
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/ghalint
+          GHALINT_VERSION: v1.5.6
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          archive="ghalint_${GHALINT_VERSION#v}_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o "/tmp/${archive}" "https://github.com/suzuki-shunsuke/ghalint/releases/download/${GHALINT_VERSION}/${archive}"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/ghalint_checksums.txt "https://github.com/suzuki-shunsuke/ghalint/releases/download/${GHALINT_VERSION}/ghalint_${GHALINT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  ${archive}$" ghalint_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp
+          sudo install -m 0755 /tmp/ghalint /usr/local/bin/ghalint
+          ghalint version
+        shell: bash
+
+      - name: Check workflow files
+        run: ghalint run
+        shell: bash
+
+      - name: Run ghalint for composite actions
+        run: ghalint run-action
+        shell: bash
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor security check
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github/workflows/
+          min-severity: medium
+          token: ${{ github.token }}
+          advanced-security: false
+          annotations: true
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.25.2
+
+  codeql-actions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        with:
+          languages: actions
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        id: analyze
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        with:
+          category: /language:actions
+          output: ../results
+          upload: never
+          upload-database: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Check CodeQL findings
+        env:
+          SARIF_DIR: ${{ steps.analyze.outputs.sarif-output }}
+        run: |
+          set -euo pipefail
+
+          sarif_file="$(find "${SARIF_DIR}" -name "*.sarif" -print -quit)"
+          if [[ -z "${sarif_file}" ]]; then
+            echo "No CodeQL SARIF file was generated." >&2
+            exit 1
+          fi
+
+          node .github/scripts/check-codeql-sarif.mjs "${sarif_file}"
+        shell: bash

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+min_age:
+  value: 7
+  always: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:best-practices", "group:definitelyTyped"],
+  minimumReleaseAge: "7 days",
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s",
+      ],
+    },
+  ],
+  packageRules: [
+    {
+      description: "Automerge minor, patch, and pin updates for production npm dependencies after a 7 day minimum release age",
+      groupName: "dependencies (non-major)",
+      matchManagers: ["npm"],
+      matchDepTypes: ["dependencies"],
+      matchUpdateTypes: ["minor", "patch", "pin"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+    {
+      description: "Automerge minor, patch, and pin updates for development npm dependencies after a 7 day minimum release age",
+      groupName: "devDependencies (non-major)",
+      matchManagers: ["npm"],
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch", "pin"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+    {
+      description: "Automerge minor, patch, digest, and pinDigest GitHub Actions updates after a 7 day minimum release age",
+      groupName: "github-actions (non-major)",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "digest", "pinDigest"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- add workflow-lint with pinact, actionlint, ghalint, zizmor, and CodeQL Actions SARIF gating
- add `.pinact.yaml` and pin existing workflow actions to full SHAs
- add Renovate config with 7 day minimum release age, GitHub Actions digest pinning, and custom regex management for workflow tool versions
- harden existing CI/release workflows with scoped permissions, timeouts, and `persist-credentials: false`

## Local checks
- `GITHUB_TOKEN=$(gh auth token) pinact run --check`
- `actionlint -color`
- `ghalint run`
- `ghalint run-action`
- `uvx zizmor .github/workflows --min-severity medium`
- `npx --yes --package renovate renovate-config-validator renovate.json5`
- `git diff --check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
